### PR TITLE
Reintroduce CodeQL scan & enable dependabot GHA updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  rebase-strategy: disabled
 - package-ecosystem: npm
   directory: /
   schedule:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+  schedule:
+    - cron: 45 23 * * 0
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+    - uses: actions/checkout@v3.5.2
+
+    - uses: github/codeql-action/init@v2.3.5
+      with:
+        languages: javascript
+
+    - uses: github/codeql-action/autobuild@v2.3.5
+
+    - uses: github/codeql-action/analyze@v2.3.5
+      with:
+        category: "/language:javascript"


### PR DESCRIPTION
- This repository is not compatible with default scans, so we need to use a workflow
- Enable GitHub Action updates using Dependabot