### PR TITLE
Fix iOS: missing "Check your email" button

### DIFF
--- a/example/ios/LinkReactNative/Info.plist
+++ b/example/ios/LinkReactNative/Info.plist
@@ -47,5 +47,11 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>googlegmail</string>
+		<string>ymail</string>
+		<string>ms-outlook</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
`LSApplicationQueriesSchemes` was missing in `.plist` file.