### PR TITLE
TASK-38066: Update upload action to v4

### DIFF
--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -49,7 +49,7 @@ jobs:
         ./gradlew assembleRelease
 
     - name: Archive APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: apk-app-development-release
         path: example/android/app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
Artifact actions v3 will be deprecated by December 5, 2024.